### PR TITLE
Fastcalls

### DIFF
--- a/scalebit.c
+++ b/scalebit.c
@@ -27,6 +27,7 @@
 #include <config.h>
 #endif
 
+#include "scalebit.h"
 #include "scale2x.h"
 #include "scale3x.h"
 
@@ -399,6 +400,20 @@ int scale_precondition(unsigned scale, unsigned pixel, unsigned width, unsigned 
 	return 0;
 }
 
+static unsigned int scale_options = SCALE2X_OPTION_DEFAULT;
+
+/**
+ * Set options for the Scale effect
+ * \param options options for the Scale effect
+ * \return previously set options for the Scale effect
+ */
+unsigned int scale_set_options(unsigned int options)
+{
+	unsigned int old_options = scale_options;
+	scale_options = options;
+	return old_options;
+}
+
 /**
  * Apply the Scale effect on a bitmap.
  * This function is simply a common interface for ::scale2x(), ::scale3x() and ::scale4x().
@@ -414,45 +429,53 @@ int scale_precondition(unsigned scale, unsigned pixel, unsigned width, unsigned 
 void scale(unsigned scale, void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned pixel, unsigned width, unsigned height)
 {
 	switch (pixel) {
+	case 1 :
 #ifdef USE_SCALE2X_SSE2
-	case 1 :
-		stage_scale2x_impl = (stage_scale2x_t)scale2x_8_sse2;
-		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_8_sse2;
-		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_8_sse2;
-		stage_scale3x_impl = (stage_scale3x_t)scale3x_8_def;
-		break;
-	case 2 :
-		stage_scale2x_impl = (stage_scale2x_t)scale2x_16_sse2;
-		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_16_sse2;
-		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_16_sse2;
-		stage_scale3x_impl = (stage_scale3x_t)scale3x_16_def;
-		break;
-	case 4 :
-		stage_scale2x_impl = (stage_scale2x_t)scale2x_32_sse2;
-		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_32_sse2;
-		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_32_sse2;
-		stage_scale3x_impl = (stage_scale3x_t)scale3x_32_def;
-		break;
-#else
-	case 1 :
-		stage_scale2x_impl = (stage_scale2x_t)scale2x_8_def;
-		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_8_def;
-		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_8_def;
-		stage_scale3x_impl = (stage_scale3x_t)scale3x_8_def;
-		break;
-	case 2 :
-		stage_scale2x_impl = (stage_scale2x_t)scale2x_16_def;
-		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_16_def;
-		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_16_def;
-		stage_scale3x_impl = (stage_scale3x_t)scale3x_16_def;
-		break;
-	case 4 :
-		stage_scale2x_impl = (stage_scale2x_t)scale2x_32_def;
-		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_32_def;
-		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_32_def;
-		stage_scale3x_impl = (stage_scale3x_t)scale3x_32_def;
-		break;
+		if (!(scale_options & SCALE2X_OPTION_NO_SSE2)) {
+			stage_scale2x_impl = (stage_scale2x_t)scale2x_8_sse2;
+			stage_scale2x3_impl = (stage_scale3x_t)scale2x3_8_sse2;
+			stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_8_sse2;
+		} else
 #endif
+		{
+			stage_scale2x_impl = (stage_scale2x_t)scale2x_8_def;
+			stage_scale2x3_impl = (stage_scale3x_t)scale2x3_8_def;
+			stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_8_def;
+		}
+		stage_scale3x_impl = (stage_scale3x_t)scale3x_8_def;
+		break;
+	case 2 :
+#ifdef USE_SCALE2X_SSE2
+		if (!(scale_options & SCALE2X_OPTION_NO_SSE2)) {
+			stage_scale2x_impl = (stage_scale2x_t)scale2x_16_sse2;
+			stage_scale2x3_impl = (stage_scale3x_t)scale2x3_16_sse2;
+			stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_16_sse2;
+		} else
+#endif
+		{
+			stage_scale2x_impl = (stage_scale2x_t)scale2x_16_def;
+			stage_scale2x3_impl = (stage_scale3x_t)scale2x3_16_def;
+			stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_16_def;
+		}
+		stage_scale3x_impl = (stage_scale3x_t)scale3x_16_def;
+		break;
+	case 4 :
+#ifdef USE_SCALE2X_SSE2
+		if (!(scale_options & SCALE2X_OPTION_NO_SSE2)) {
+			stage_scale2x_impl = (stage_scale2x_t)scale2x_32_sse2;
+			stage_scale2x3_impl = (stage_scale3x_t)scale2x3_32_sse2;
+			stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_32_sse2;
+		} else
+#endif
+		{
+			stage_scale2x_impl = (stage_scale2x_t)scale2x_32_def;
+			stage_scale2x3_impl = (stage_scale3x_t)scale2x3_32_def;
+			stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_32_def;
+		}
+		stage_scale3x_impl = (stage_scale3x_t)scale3x_32_def;
+		break;
+	default :
+		return;
 	}
 	switch (scale) {
 	case 202 :

--- a/scalebit.c
+++ b/scalebit.c
@@ -37,82 +37,41 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#define SSDST(bits, num) (scale2x_uint ## bits *)dst ## num
-#define SSSRC(bits, num) (const scale2x_uint ## bits *)src ## num
+typedef void (*stage_scale2x_t)(void* dst0, void* dst1, const void* src0, const void* src1, const void* src2, unsigned pixel_per_row);
+typedef void (*stage_scale3x_t)(void* dst0, void* dst1, void* dst2, const void* src0, const void* src1, const void* src2, unsigned pixel_per_row);
+typedef void (*stage_scale2x4_t)(void* dst0, void* dst1, void* dst2, void* dst3, const void* src0, const void* src1, const void* src2, unsigned pixel_per_row);
 
 /**
  * Apply the Scale2x effect on a group of rows. Used internally.
  */
-static inline void stage_scale2x(void* dst0, void* dst1, const void* src0, const void* src1, const void* src2, unsigned pixel, unsigned pixel_per_row)
-{
-	switch (pixel) {
-#ifdef USE_SCALE2X_SSE2
-	case 1 : scale2x_8_sse2(SSDST(8, 0), SSDST(8, 1), SSSRC(8, 0), SSSRC(8, 1), SSSRC(8, 2), pixel_per_row); break;
-	case 2 : scale2x_16_sse2(SSDST(16, 0), SSDST(16, 1), SSSRC(16, 0), SSSRC(16, 1), SSSRC(16, 2), pixel_per_row); break;
-	case 4 : scale2x_32_sse2(SSDST(32, 0), SSDST(32, 1), SSSRC(32, 0), SSSRC(32, 1), SSSRC(32, 2), pixel_per_row); break;
-#else
-	case 1 : scale2x_8_def(SSDST(8, 0), SSDST(8, 1), SSSRC(8, 0), SSSRC(8, 1), SSSRC(8, 2), pixel_per_row); break;
-	case 2 : scale2x_16_def(SSDST(16, 0), SSDST(16, 1), SSSRC(16, 0), SSSRC(16, 1), SSSRC(16, 2), pixel_per_row); break;
-	case 4 : scale2x_32_def(SSDST(32, 0), SSDST(32, 1), SSSRC(32, 0), SSSRC(32, 1), SSSRC(32, 2), pixel_per_row); break;
-#endif
-	}
-}
+#define stage_scale2x(dst0, dst1, src0, src1, src2, pixel, pixel_per_row) stage_scale2x_impl(dst0, dst1, src0, src1, src2, pixel_per_row)
+stage_scale2x_t stage_scale2x_impl = NULL;
 
 /**
  * Apply the Scale2x3 effect on a group of rows. Used internally.
  */
-static inline void stage_scale2x3(void* dst0, void* dst1, void* dst2, const void* src0, const void* src1, const void* src2, unsigned pixel, unsigned pixel_per_row)
-{
-	switch (pixel) {
-#ifdef USE_SCALE2X_SSE2
-	case 1 : scale2x3_8_sse2(SSDST(8, 0), SSDST(8, 1), SSDST(8, 2), SSSRC(8, 0), SSSRC(8, 1), SSSRC(8, 2), pixel_per_row); break;
-	case 2 : scale2x3_16_sse2(SSDST(16, 0), SSDST(16, 1), SSDST(16, 2), SSSRC(16, 0), SSSRC(16, 1), SSSRC(16, 2), pixel_per_row); break;
-	case 4 : scale2x3_32_sse2(SSDST(32, 0), SSDST(32, 1), SSDST(32, 2), SSSRC(32, 0), SSSRC(32, 1), SSSRC(32, 2), pixel_per_row); break;
-#else
-	case 1 : scale2x3_8_def(SSDST(8, 0), SSDST(8, 1), SSDST(8, 2), SSSRC(8, 0), SSSRC(8, 1), SSSRC(8, 2), pixel_per_row); break;
-	case 2 : scale2x3_16_def(SSDST(16, 0), SSDST(16, 1), SSDST(16, 2), SSSRC(16, 0), SSSRC(16, 1), SSSRC(16, 2), pixel_per_row); break;
-	case 4 : scale2x3_32_def(SSDST(32, 0), SSDST(32, 1), SSDST(32, 2), SSSRC(32, 0), SSSRC(32, 1), SSSRC(32, 2), pixel_per_row); break;
-#endif
-	}
-}
+#define stage_scale2x3(dst0, dst1, dst2, src0, src1, src2, pixel, pixel_per_row) stage_scale2x3_impl(dst0, dst1, dst2, src0, src1, src2, pixel_per_row)
+stage_scale3x_t stage_scale2x3_impl = NULL;
 
 /**
  * Apply the Scale2x4 effect on a group of rows. Used internally.
  */
-static inline void stage_scale2x4(void* dst0, void* dst1, void* dst2, void* dst3, const void* src0, const void* src1, const void* src2, unsigned pixel, unsigned pixel_per_row)
-{
-	switch (pixel) {
-#ifdef USE_SCALE2X_SSE2
-	case 1 : scale2x4_8_sse2(SSDST(8, 0), SSDST(8, 1), SSDST(8, 2), SSDST(8, 3), SSSRC(8, 0), SSSRC(8, 1), SSSRC(8, 2), pixel_per_row); break;
-	case 2 : scale2x4_16_sse2(SSDST(16, 0), SSDST(16, 1), SSDST(16, 2), SSDST(16, 3), SSSRC(16, 0), SSSRC(16, 1), SSSRC(16, 2), pixel_per_row); break;
-	case 4 : scale2x4_32_sse2(SSDST(32, 0), SSDST(32, 1), SSDST(32, 2), SSDST(32, 3), SSSRC(32, 0), SSSRC(32, 1), SSSRC(32, 2), pixel_per_row); break;
-#else
-	case 1 : scale2x4_8_def(SSDST(8, 0), SSDST(8, 1), SSDST(8, 2), SSDST(8, 3), SSSRC(8, 0), SSSRC(8, 1), SSSRC(8, 2), pixel_per_row); break;
-	case 2 : scale2x4_16_def(SSDST(16, 0), SSDST(16, 1), SSDST(16, 2), SSDST(16, 3), SSSRC(16, 0), SSSRC(16, 1), SSSRC(16, 2), pixel_per_row); break;
-	case 4 : scale2x4_32_def(SSDST(32, 0), SSDST(32, 1), SSDST(32, 2), SSDST(32, 3), SSSRC(32, 0), SSSRC(32, 1), SSSRC(32, 2), pixel_per_row); break;
-#endif
-	}
-}
+#define stage_scale2x4(dst0, dst1, dst2, dst3, src0, src1, src2, pixel, pixel_per_row) stage_scale2x4_impl(dst0, dst1, dst2, dst3, src0, src1, src2, pixel_per_row)
+stage_scale2x4_t stage_scale2x4_impl = NULL;
 
 /**
  * Apply the Scale3x effect on a group of rows. Used internally.
  */
-static inline void stage_scale3x(void* dst0, void* dst1, void* dst2, const void* src0, const void* src1, const void* src2, unsigned pixel, unsigned pixel_per_row)
-{
-	switch (pixel) {
-	case 1 : scale3x_8_def(SSDST(8, 0), SSDST(8, 1), SSDST(8, 2), SSSRC(8, 0), SSSRC(8, 1), SSSRC(8, 2), pixel_per_row); break;
-	case 2 : scale3x_16_def(SSDST(16, 0), SSDST(16, 1), SSDST(16, 2), SSSRC(16, 0), SSSRC(16, 1), SSSRC(16, 2), pixel_per_row); break;
-	case 4 : scale3x_32_def(SSDST(32, 0), SSDST(32, 1), SSDST(32, 2), SSSRC(32, 0), SSSRC(32, 1), SSSRC(32, 2), pixel_per_row); break;
-	}
-}
+#define stage_scale3x(dst0, dst1, dst2, src0, src1, src2, pixel, pixel_per_row) stage_scale3x_impl(dst0, dst1, dst2, src0, src1, src2, pixel_per_row)
+stage_scale3x_t stage_scale3x_impl = NULL;
 
 /**
  * Apply the Scale4x effect on a group of rows. Used internally.
  */
-static inline void stage_scale4x(void* dst0, void* dst1, void* dst2, void* dst3, const void* src0, const void* src1, const void* src2, const void* src3, unsigned pixel, unsigned pixel_per_row)
+static inline void stage_scale4x(void* dst0, void* dst1, void* dst2, void* dst3, const void* src0, const void* src1, const void* src2, const void* src3, unsigned pixel_per_row)
 {
-	stage_scale2x(dst0, dst1, src0, src1, src2, pixel, 2 * pixel_per_row);
-	stage_scale2x(dst2, dst3, src1, src2, src3, pixel, 2 * pixel_per_row);
+	stage_scale2x_impl(dst0, dst1, src0, src1, src2, 2 * pixel_per_row);
+	stage_scale2x_impl(dst2, dst3, src1, src2, src3, 2 * pixel_per_row);
 }
 
 #define SCDST(i) (dst + (i) * dst_slice)
@@ -129,11 +88,10 @@ static inline void stage_scale4x(void* dst0, void* dst1, void* dst2, void* dst3,
  * \param dst_slice Size in bytes of a destination bitmap row.
  * \param void_src Pointer at the first pixel of the source bitmap.
  * \param src_slice Size in bytes of a source bitmap row.
- * \param pixel Bytes per pixel of the source and destination bitmap.
  * \param width Horizontal size in pixels of the source bitmap.
  * \param height Vertical size in pixels of the source bitmap.
  */
-static void scale2x(void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned pixel, unsigned width, unsigned height)
+static void scale2x(void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned width, unsigned height)
 {
 	unsigned char* dst = (unsigned char*)void_dst;
 	const unsigned char* src = (const unsigned char*)void_src;
@@ -170,11 +128,10 @@ static void scale2x(void* void_dst, unsigned dst_slice, const void* void_src, un
  * \param dst_slice Size in bytes of a destination bitmap row.
  * \param void_src Pointer at the first pixel of the source bitmap.
  * \param src_slice Size in bytes of a source bitmap row.
- * \param pixel Bytes per pixel of the source and destination bitmap.
  * \param width Horizontal size in pixels of the source bitmap.
  * \param height Vertical size in pixels of the source bitmap.
  */
-static void scale2x3(void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned pixel, unsigned width, unsigned height)
+static void scale2x3(void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned width, unsigned height)
 {
 	unsigned char* dst = (unsigned char*)void_dst;
 	const unsigned char* src = (const unsigned char*)void_src;
@@ -211,11 +168,10 @@ static void scale2x3(void* void_dst, unsigned dst_slice, const void* void_src, u
  * \param dst_slice Size in bytes of a destination bitmap row.
  * \param void_src Pointer at the first pixel of the source bitmap.
  * \param src_slice Size in bytes of a source bitmap row.
- * \param pixel Bytes per pixel of the source and destination bitmap.
  * \param width Horizontal size in pixels of the source bitmap.
  * \param height Vertical size in pixels of the source bitmap.
  */
-static void scale2x4(void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned pixel, unsigned width, unsigned height)
+static void scale2x4(void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned width, unsigned height)
 {
 	unsigned char* dst = (unsigned char*)void_dst;
 	const unsigned char* src = (const unsigned char*)void_src;
@@ -252,11 +208,10 @@ static void scale2x4(void* void_dst, unsigned dst_slice, const void* void_src, u
  * \param dst_slice Size in bytes of a destination bitmap row.
  * \param void_src Pointer at the first pixel of the source bitmap.
  * \param src_slice Size in bytes of a source bitmap row.
- * \param pixel Bytes per pixel of the source and destination bitmap.
  * \param width Horizontal size in pixels of the source bitmap.
  * \param height Vertical size in pixels of the source bitmap.
  */
-static void scale3x(void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned pixel, unsigned width, unsigned height)
+static void scale3x(void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned width, unsigned height)
 {
 	unsigned char* dst = (unsigned char*)void_dst;
 	const unsigned char* src = (const unsigned char*)void_src;
@@ -300,11 +255,10 @@ static void scale3x(void* void_dst, unsigned dst_slice, const void* void_src, un
  * \param mid_slice Size in bytes of a buffer bitmap row.
  * \param void_src Pointer at the first pixel of the source bitmap.
  * \param src_slice Size in bytes of a source bitmap row.
- * \param pixel Bytes per pixel of the source and destination bitmap.
  * \param width Horizontal size in pixels of the source bitmap.
  * \param height Vertical size in pixels of the source bitmap.
  */
-static void scale4x_buf(void* void_dst, unsigned dst_slice, void* void_mid, unsigned mid_slice, const void* void_src, unsigned src_slice, unsigned pixel, unsigned width, unsigned height)
+static void scale4x_buf(void* void_dst, unsigned dst_slice, void* void_mid, unsigned mid_slice, const void* void_src, unsigned src_slice, unsigned width, unsigned height)
 {
 	unsigned char* dst = (unsigned char*)void_dst;
 	const unsigned char* src = (const unsigned char*)void_src;
@@ -326,11 +280,11 @@ static void scale4x_buf(void* void_dst, unsigned dst_slice, void* void_mid, unsi
 	stage_scale2x(SCMID(-2 + 6), SCMID(-1 + 6), SCSRC(0), SCSRC(0), SCSRC(1), pixel, width);
 	stage_scale2x(SCMID(0), SCMID(1), SCSRC(0), SCSRC(1), SCSRC(2), pixel, width);
 	stage_scale2x(SCMID(2), SCMID(3), SCSRC(1), SCSRC(2), SCSRC(3), pixel, width);
-	stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(-2 + 6), SCMID(-2 + 6), SCMID(-1 + 6), SCMID(0), pixel, width);
+	stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(-2 + 6), SCMID(-2 + 6), SCMID(-1 + 6), SCMID(0), width);
 
 	dst = SCDST(4);
 
-	stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(-1 + 6), SCMID(0), SCMID(1), SCMID(2), pixel, width);
+	stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(-1 + 6), SCMID(0), SCMID(1), SCMID(2), width);
 
 	dst = SCDST(4);
 
@@ -339,7 +293,7 @@ static void scale4x_buf(void* void_dst, unsigned dst_slice, void* void_mid, unsi
 		unsigned char* tmp;
 
 		stage_scale2x(SCMID(4), SCMID(5), SCSRC(2), SCSRC(3), SCSRC(4), pixel, width);
-		stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(1), SCMID(2), SCMID(3), SCMID(4), pixel, width);
+		stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(1), SCMID(2), SCMID(3), SCMID(4), width);
 
 		dst = SCDST(4);
 		src = SCSRC(1);
@@ -357,11 +311,11 @@ static void scale4x_buf(void* void_dst, unsigned dst_slice, void* void_mid, unsi
 	}
 
 	stage_scale2x(SCMID(4), SCMID(5), SCSRC(2), SCSRC(3), SCSRC(3), pixel, width);
-	stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(1), SCMID(2), SCMID(3), SCMID(4), pixel, width);
+	stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(1), SCMID(2), SCMID(3), SCMID(4), width);
 
 	dst = SCDST(4);
 
-	stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(3), SCMID(4), SCMID(5), SCMID(5), pixel, width);
+	stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(3), SCMID(4), SCMID(5), SCMID(5), width);
 }
 
 /**
@@ -402,7 +356,7 @@ static void scale4x(void* void_dst, unsigned dst_slice, const void* void_src, un
 
 	mid_ptr = scale2x_align_ptr(mid_alloc);
 
-	scale4x_buf(void_dst, dst_slice, mid_ptr, mid_slice, void_src, src_slice, pixel, width, height);
+	scale4x_buf(void_dst, dst_slice, mid_ptr, mid_slice, void_src, src_slice, width, height);
 
 #if !HAVE_ALLOCA
 	free(mid_alloc);
@@ -463,20 +417,61 @@ int scale_precondition(unsigned scale, unsigned pixel, unsigned width, unsigned 
  */
 void scale(unsigned scale, void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned pixel, unsigned width, unsigned height)
 {
+	switch (pixel) {
+#ifdef USE_SCALE2X_SSE2
+	case 1 :
+		stage_scale2x_impl = (stage_scale2x_t)scale2x_8_sse2;
+		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_8_sse2;
+		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_8_sse2;
+		stage_scale3x_impl = (stage_scale3x_t)scale3x_8_def;
+		break;
+	case 2 :
+		stage_scale2x_impl = (stage_scale2x_t)scale2x_16_sse2;
+		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_16_sse2;
+		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_16_sse2;
+		stage_scale3x_impl = (stage_scale3x_t)scale3x_16_def;
+		break;
+	case 4 :
+		stage_scale2x_impl = (stage_scale2x_t)scale2x_32_sse2;
+		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_32_sse2;
+		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_32_sse2;
+		stage_scale3x_impl = (stage_scale3x_t)scale3x_32_def;
+		break;
+#else
+	case 1 :
+		stage_scale2x_impl = (stage_scale2x_t)scale2x_8_def;
+		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_8_def;
+		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_8_def;
+		stage_scale3x_impl = (stage_scale3x_t)scale3x_8_def;
+		break;
+	case 2 :
+		stage_scale2x_impl = (stage_scale2x_t)scale2x_16_def;
+		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_16_def;
+		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_16_def;
+		stage_scale3x_impl = (stage_scale3x_t)scale3x_16_def;
+		break;
+	case 4 :
+		stage_scale2x_impl = (stage_scale2x_t)scale2x_32_def;
+		stage_scale2x3_impl = (stage_scale3x_t)scale2x3_32_def;
+		stage_scale2x4_impl = (stage_scale2x4_t)scale2x4_32_def;
+		stage_scale3x_impl = (stage_scale3x_t)scale3x_32_def;
+		break;
+#endif
+	}
 	switch (scale) {
 	case 202 :
 	case 2 :
-		scale2x(void_dst, dst_slice, void_src, src_slice, pixel, width, height);
+		scale2x(void_dst, dst_slice, void_src, src_slice, width, height);
 		break;
 	case 203 :
-		scale2x3(void_dst, dst_slice, void_src, src_slice, pixel, width, height);
+		scale2x3(void_dst, dst_slice, void_src, src_slice, width, height);
 		break;
 	case 204 :
-		scale2x4(void_dst, dst_slice, void_src, src_slice, pixel, width, height);
+		scale2x4(void_dst, dst_slice, void_src, src_slice, width, height);
 		break;
 	case 303 :
 	case 3 :
-		scale3x(void_dst, dst_slice, void_src, src_slice, pixel, width, height);
+		scale3x(void_dst, dst_slice, void_src, src_slice, width, height);
 		break;
 	case 404 :
 	case 4 :

--- a/scalebit.c
+++ b/scalebit.c
@@ -44,26 +44,22 @@ typedef void (*stage_scale2x4_t)(void* dst0, void* dst1, void* dst2, void* dst3,
 /**
  * Apply the Scale2x effect on a group of rows. Used internally.
  */
-#define stage_scale2x(dst0, dst1, src0, src1, src2, pixel, pixel_per_row) stage_scale2x_impl(dst0, dst1, src0, src1, src2, pixel_per_row)
-stage_scale2x_t stage_scale2x_impl = NULL;
+static stage_scale2x_t stage_scale2x_impl = NULL;
 
 /**
  * Apply the Scale2x3 effect on a group of rows. Used internally.
  */
-#define stage_scale2x3(dst0, dst1, dst2, src0, src1, src2, pixel, pixel_per_row) stage_scale2x3_impl(dst0, dst1, dst2, src0, src1, src2, pixel_per_row)
-stage_scale3x_t stage_scale2x3_impl = NULL;
+static stage_scale3x_t stage_scale2x3_impl = NULL;
 
 /**
  * Apply the Scale2x4 effect on a group of rows. Used internally.
  */
-#define stage_scale2x4(dst0, dst1, dst2, dst3, src0, src1, src2, pixel, pixel_per_row) stage_scale2x4_impl(dst0, dst1, dst2, dst3, src0, src1, src2, pixel_per_row)
-stage_scale2x4_t stage_scale2x4_impl = NULL;
+static stage_scale2x4_t stage_scale2x4_impl = NULL;
 
 /**
  * Apply the Scale3x effect on a group of rows. Used internally.
  */
-#define stage_scale3x(dst0, dst1, dst2, src0, src1, src2, pixel, pixel_per_row) stage_scale3x_impl(dst0, dst1, dst2, src0, src1, src2, pixel_per_row)
-stage_scale3x_t stage_scale3x_impl = NULL;
+static stage_scale3x_t stage_scale3x_impl = NULL;
 
 /**
  * Apply the Scale4x effect on a group of rows. Used internally.
@@ -101,13 +97,13 @@ static void scale2x(void* void_dst, unsigned dst_slice, const void* void_src, un
 
 	count = height;
 
-	stage_scale2x(SCDST(0), SCDST(1), SCSRC(0), SCSRC(0), SCSRC(1), pixel, width);
+	stage_scale2x_impl(SCDST(0), SCDST(1), SCSRC(0), SCSRC(0), SCSRC(1), width);
 
 	dst = SCDST(2);
 
 	count -= 2;
 	while (count) {
-		stage_scale2x(SCDST(0), SCDST(1), SCSRC(0), SCSRC(1), SCSRC(2), pixel, width);
+		stage_scale2x_impl(SCDST(0), SCDST(1), SCSRC(0), SCSRC(1), SCSRC(2), width);
 
 		dst = SCDST(2);
 		src = SCSRC(1);
@@ -115,7 +111,7 @@ static void scale2x(void* void_dst, unsigned dst_slice, const void* void_src, un
 		--count;
 	}
 
-	stage_scale2x(SCDST(0), SCDST(1), SCSRC(0), SCSRC(1), SCSRC(1), pixel, width);
+	stage_scale2x_impl(SCDST(0), SCDST(1), SCSRC(0), SCSRC(1), SCSRC(1), width);
 }
 
 /**
@@ -141,13 +137,13 @@ static void scale2x3(void* void_dst, unsigned dst_slice, const void* void_src, u
 
 	count = height;
 
-	stage_scale2x3(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(0), SCSRC(1), pixel, width);
+	stage_scale2x3_impl(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(0), SCSRC(1), width);
 
 	dst = SCDST(3);
 
 	count -= 2;
 	while (count) {
-		stage_scale2x3(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(1), SCSRC(2), pixel, width);
+		stage_scale2x3_impl(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(1), SCSRC(2), width);
 
 		dst = SCDST(3);
 		src = SCSRC(1);
@@ -155,7 +151,7 @@ static void scale2x3(void* void_dst, unsigned dst_slice, const void* void_src, u
 		--count;
 	}
 
-	stage_scale2x3(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(1), SCSRC(1), pixel, width);
+	stage_scale2x3_impl(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(1), SCSRC(1), width);
 }
 
 /**
@@ -181,13 +177,13 @@ static void scale2x4(void* void_dst, unsigned dst_slice, const void* void_src, u
 
 	count = height;
 
-	stage_scale2x4(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCSRC(0), SCSRC(0), SCSRC(1), pixel, width);
+	stage_scale2x4_impl(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCSRC(0), SCSRC(0), SCSRC(1), width);
 
 	dst = SCDST(4);
 
 	count -= 2;
 	while (count) {
-		stage_scale2x4(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCSRC(0), SCSRC(1), SCSRC(2), pixel, width);
+		stage_scale2x4_impl(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCSRC(0), SCSRC(1), SCSRC(2), width);
 
 		dst = SCDST(4);
 		src = SCSRC(1);
@@ -195,7 +191,7 @@ static void scale2x4(void* void_dst, unsigned dst_slice, const void* void_src, u
 		--count;
 	}
 
-	stage_scale2x4(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCSRC(0), SCSRC(1), SCSRC(1), pixel, width);
+	stage_scale2x4_impl(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCSRC(0), SCSRC(1), SCSRC(1), width);
 }
 
 /**
@@ -221,13 +217,13 @@ static void scale3x(void* void_dst, unsigned dst_slice, const void* void_src, un
 
 	count = height;
 
-	stage_scale3x(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(0), SCSRC(1), pixel, width);
+	stage_scale3x_impl(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(0), SCSRC(1), width);
 
 	dst = SCDST(3);
 
 	count -= 2;
 	while (count) {
-		stage_scale3x(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(1), SCSRC(2), pixel, width);
+		stage_scale3x_impl(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(1), SCSRC(2), width);
 
 		dst = SCDST(3);
 		src = SCSRC(1);
@@ -235,7 +231,7 @@ static void scale3x(void* void_dst, unsigned dst_slice, const void* void_src, un
 		--count;
 	}
 
-	stage_scale3x(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(1), SCSRC(1), pixel, width);
+	stage_scale3x_impl(SCDST(0), SCDST(1), SCDST(2), SCSRC(0), SCSRC(1), SCSRC(1), width);
 }
 
 /**
@@ -277,9 +273,9 @@ static void scale4x_buf(void* void_dst, unsigned dst_slice, void* void_mid, unsi
 	mid[4] = mid[3] + mid_slice;
 	mid[5] = mid[4] + mid_slice;
 
-	stage_scale2x(SCMID(-2 + 6), SCMID(-1 + 6), SCSRC(0), SCSRC(0), SCSRC(1), pixel, width);
-	stage_scale2x(SCMID(0), SCMID(1), SCSRC(0), SCSRC(1), SCSRC(2), pixel, width);
-	stage_scale2x(SCMID(2), SCMID(3), SCSRC(1), SCSRC(2), SCSRC(3), pixel, width);
+	stage_scale2x_impl(SCMID(-2 + 6), SCMID(-1 + 6), SCSRC(0), SCSRC(0), SCSRC(1), width);
+	stage_scale2x_impl(SCMID(0), SCMID(1), SCSRC(0), SCSRC(1), SCSRC(2), width);
+	stage_scale2x_impl(SCMID(2), SCMID(3), SCSRC(1), SCSRC(2), SCSRC(3), width);
 	stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(-2 + 6), SCMID(-2 + 6), SCMID(-1 + 6), SCMID(0), width);
 
 	dst = SCDST(4);
@@ -292,7 +288,7 @@ static void scale4x_buf(void* void_dst, unsigned dst_slice, void* void_mid, unsi
 	while (count) {
 		unsigned char* tmp;
 
-		stage_scale2x(SCMID(4), SCMID(5), SCSRC(2), SCSRC(3), SCSRC(4), pixel, width);
+		stage_scale2x_impl(SCMID(4), SCMID(5), SCSRC(2), SCSRC(3), SCSRC(4), width);
 		stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(1), SCMID(2), SCMID(3), SCMID(4), width);
 
 		dst = SCDST(4);
@@ -310,7 +306,7 @@ static void scale4x_buf(void* void_dst, unsigned dst_slice, void* void_mid, unsi
 		--count;
 	}
 
-	stage_scale2x(SCMID(4), SCMID(5), SCSRC(2), SCSRC(3), SCSRC(3), pixel, width);
+	stage_scale2x_impl(SCMID(4), SCMID(5), SCSRC(2), SCSRC(3), SCSRC(3), width);
 	stage_scale4x(SCDST(0), SCDST(1), SCDST(2), SCDST(3), SCMID(1), SCMID(2), SCMID(3), SCMID(4), width);
 
 	dst = SCDST(4);

--- a/scalebit.h
+++ b/scalebit.h
@@ -26,6 +26,10 @@
 #ifndef __SCALEBIT_H
 #define __SCALEBIT_H
 
+#define SCALE2X_OPTION_DEFAULT	0
+#define SCALE2X_OPTION_NO_SSE2	0x001
+
+unsigned int scale_set_options(unsigned int options);
 int scale_precondition(unsigned scale, unsigned pixel, unsigned width, unsigned height);
 void scale(unsigned scale, void* void_dst, unsigned dst_slice, const void* void_src, unsigned src_slice, unsigned pixel, unsigned width, unsigned height);
 

--- a/scalex.c
+++ b/scalex.c
@@ -205,9 +205,10 @@ void usage(void)
 #ifdef USE_SCALE2X_SSE2
 	printf("(using SSE2 optimization)\n");
 #endif
-	printf("\nSyntax: scalex [-k N] FROM.png TO.png\n");
+	printf("\nSyntax: scalex [-o options] [-k N] FROM.png TO.png\n");
 	printf("\nOptions:\n");
 	printf("\t-k N\tSelect the scale factor. 2, 2x3, 2x4, 3 or 4. (default 2).\n");
+	printf("\t-o\tnosse2 : disable SSE2\n");
 	printf("\nMore info at " PACKAGE_URL "\n");
 	exit(EXIT_FAILURE);
 }
@@ -215,6 +216,7 @@ void usage(void)
 #ifdef HAVE_GETOPT_LONG
 struct option long_options[] = {
 	{ "scale", 1, 0, 'k' },
+	{ "options", 1, 0, 'o' },
 	{ "speed", 0, 0, 'T' },
 	{ "crc", 0, 0, 'c' },
 	{ "help", 0, 0, 'h' },
@@ -223,7 +225,7 @@ struct option long_options[] = {
 };
 #endif
 
-#define OPTIONS "k:Tchv"
+#define OPTIONS "k:o:Tchv"
 
 int main(int argc, char* argv[])
 {
@@ -267,6 +269,14 @@ int main(int argc, char* argv[])
 					printf("Invalid -k option. Valid values are 2, 2x3, 2x4, 3 and 4.\n");
 					exit(EXIT_FAILURE);
 				}
+			}
+			break;
+		case 'o' :
+			if (strcmp(optarg, "nosse2") == 0) {
+				scale_set_options(SCALE2X_OPTION_NO_SSE2);
+			} else {
+				printf("Invalid -o option. Valid values are : nosse2.\n");
+				exit(EXIT_FAILURE);
 			}
 			break;
 		case 'c' :


### PR DESCRIPTION
make stage_scale2x() etc. functions call directly the right implementation.

Step 2 : add option to be able to disable SSE2 implementation at runtime